### PR TITLE
Rewarded Interstitial path missing.

### DIFF
--- a/MobileFuseAdapter/src/main/java/com/chartboost/mediation/mobilefuseadapter/MobileFuseAdapter.kt
+++ b/MobileFuseAdapter/src/main/java/com/chartboost/mediation/mobilefuseadapter/MobileFuseAdapter.kt
@@ -271,6 +271,7 @@ class MobileFuseAdapter : PartnerAdapter {
 
             else -> {
                 if (request.format.key == "rewarded_interstitial") {
+                    // MobileFuse does not have a specific rewarded interstitial class.
                     loadRewardedAd(
                         context,
                         request,


### PR DESCRIPTION
- Our adapter was not able to properly load and show rewarded interstitial ads as it was missing.