### PR TITLE
4.1.7.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.1.7.6.0
+- This version of the adapter has been certified with MobileFuse SDK 1.7.6.
+
 ### 4.1.7.5.0
 - This version of the adapter has been certified with MobileFuse SDK 1.7.5.
 

--- a/MobileFuseAdapter/build.gradle.kts
+++ b/MobileFuseAdapter/build.gradle.kts
@@ -34,7 +34,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.1.7.5.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.1.7.6.0"
 
         buildConfigField(
             "String",
@@ -74,7 +74,7 @@ dependencies {
     "remoteImplementation"("com.chartboost:chartboost-mediation-sdk:4.0.0")
 
     // Partner SDK
-    implementation("com.mobilefuse.sdk:mobilefuse-sdk-core:1.7.5")
+    implementation("com.mobilefuse.sdk:mobilefuse-sdk-core:1.7.6")
 
     // Adapter Dependencies
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation MobileFuse adapter mediates MobileFuse SDK Core via the
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-mobilefuse:4.1.7.5.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-mobilefuse:4.1.7.6.0"
 ```
 
 ## Contributions


### PR DESCRIPTION
Updates the MobileFuse adapter to `4.1.7.6.0`.

Do not merge.